### PR TITLE
Added better link to ProGamerGov's color transfer code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Public domain.
 
 **Experimental**, don't expect miracles from it.
 
-Based on [Leon Gatys's](https://github.com/leongatys/NeuralImageSynthesis), [ProGamerGov's](https://github.com/jcjohnson/neural-style/issues/376), [Adrian Rosebrock's](https://github.com/jrosebr1/color_transfer), [François Pitié's](https://github.com/frcs/colour-transfer), [mdfirman's](https://github.com/mdfirman/python_colour_transfer) code and different research papers (given in descriptions of functions).
+Based on [Leon Gatys's](https://github.com/leongatys/NeuralImageSynthesis), [ProGamerGov's](https://github.com/ProGamerGov/Neural-Tools), [Adrian Rosebrock's](https://github.com/jrosebr1/color_transfer), [François Pitié's](https://github.com/frcs/colour-transfer), [mdfirman's](https://github.com/mdfirman/python_colour_transfer) code and different research papers (given in descriptions of functions).
 
 **Example**:
 

--- a/colorizer.lua
+++ b/colorizer.lua
@@ -422,7 +422,7 @@ function match_color(target_img, source_img, mode, eps)
   end
 
   -- from Leon Gatys's code: https://github.com/leongatys/NeuralImageSynthesis/blob/master/ExampleNotebooks/ColourControl.ipynb
-  -- and ProGamerGov's code: https://github.com/jcjohnson/neural-style/issues/376
+  -- and ProGamerGov's code: https://github.com/jcjohnson/neural-style/issues/376, https://github.com/ProGamerGov/Neural-Tools
   local eyem = torch.eye(source_img:size(1)):mul(eps)
 
   local mu_s = torch.mean(source_img, 3):mean(2)


### PR DESCRIPTION
The color transfer code from here: https://github.com/jcjohnson/neural-style/issues/376, exists in a more complete and updated form here: https://github.com/ProGamerGov/Neural-Tools. The Neural-Tools project also contains an extensive [wiki](https://github.com/ProGamerGov/Neural-Tools/wiki) on using the color transfer scripts in relation to style transfer. 